### PR TITLE
hot fix for chams, remove last arg from createmove and add back input history

### DIFF
--- a/cstrike/core/hooks.cpp
+++ b/cstrike/core/hooks.cpp
@@ -192,10 +192,10 @@ ViewMatrix_t* CS_FASTCALL H::GetMatrixForView(CRenderGameSystem* pRenderGameSyst
 	return matResult;
 }
 
-bool CS_FASTCALL H::CreateMove(CCSGOInput* pInput, int nSlot, bool bActive, std::byte unk)
+bool CS_FASTCALL H::CreateMove(CCSGOInput* pInput, int nSlot, bool bActive)
 {
 	const auto oCreateMove = hkCreateMove.GetOriginal();
-	const bool bResult = oCreateMove(pInput, nSlot, bActive, unk);
+	const bool bResult = oCreateMove(pInput, nSlot, bActive);
 
 	if (!I::Engine->IsConnected() || !I::Engine->IsInGame())
 		return bResult;

--- a/cstrike/core/hooks.h
+++ b/cstrike/core/hooks.h
@@ -61,7 +61,7 @@ namespace H
 
 	// game's functions
 	ViewMatrix_t* CS_FASTCALL GetMatrixForView(CRenderGameSystem* pRenderGameSystem, IViewRender* pViewRender, ViewMatrix_t* pOutWorldToView, ViewMatrix_t* pOutViewToProjection, ViewMatrix_t* pOutWorldToProjection, ViewMatrix_t* pOutWorldToPixels);
-	bool CS_FASTCALL CreateMove(CCSGOInput* pInput, int nSlot, bool bActive, std::byte unk);
+	bool CS_FASTCALL CreateMove(CCSGOInput* pInput, int nSlot, bool bActive);
 	bool CS_FASTCALL MouseInputEnabled(void* pThisptr);
 	void CS_FASTCALL FrameStageNotify(void* rcx, int nFrameStage);
 	__int64* CS_FASTCALL LevelInit(void* pClientModeShared, const char* szNewMap);

--- a/cstrike/core/menu.cpp
+++ b/cstrike/core/menu.cpp
@@ -465,6 +465,8 @@ void T::Miscellaneous()
 			if (C_GET(bool, Vars.bAutoBHop))
 				ImGui::SliderInt(CS_XOR("chance"), &C_GET(int, Vars.nAutoBHopChance), 0, 100, CS_XOR("%d%%"));
 
+			ImGui::Checkbox(CS_XOR("auto strafe"), &C_GET(bool, Vars.bAutoStrafe));
+
 			ImGui::PopStyleVar();
 		}
 		ImGui::EndChild();

--- a/cstrike/core/variables.h
+++ b/cstrike/core/variables.h
@@ -70,6 +70,8 @@ struct Variables_t
 
 	C_ADD_VARIABLE(bool, bAutoBHop, false);
 	C_ADD_VARIABLE(int, nAutoBHopChance, 100);
+
+	C_ADD_VARIABLE(bool, bAutoStrafe, false);
 #pragma endregion
 
 #pragma region variables_menu

--- a/cstrike/features/misc/movement.cpp
+++ b/cstrike/features/misc/movement.cpp
@@ -32,18 +32,18 @@ void F::MISC::MOVEMENT::OnMove(CUserCmd* pCmd, CCSPlayerController* pLocalContro
 	AutoStrafe(pBaseCmd, pLocalPawn);
 
 	// loop through all tick commands
-	//for (int nTick = 0; nTick < pBaseCmd->nTickCount; nTick++)
-	//{
-	//	CCSGOInputHistoryEntryPB* pInputEntry = pCmd->cmd.inputHistoryField.pRep->tElements[nTick];
-	//	if (pInputEntry == nullptr)
-	//		continue;
+	for (int nTick = 0; nTick < pBaseCmd->nTickCount; nTick++)
+	{
+		CCSGOInputHistoryEntryPB* pInputEntry = pCmd->csgoUserCmd.GetInputHistoryEntry(nTick);
+		if (pInputEntry == nullptr)
+			continue;
 
-	//	// save view angles for movement correction
-	//	angCorrectionView = pInputEntry->pViewCmd->angValue;
+		// save view angles for movement correction
+		angCorrectionView = pInputEntry->pViewCmd->angValue;
 
-	//	// movement correction & anti-untrusted
-	//	ValidateUserCommand(pCmd, pBaseCmd, pInputEntry);
-	//}
+		// movement correction & anti-untrusted
+		ValidateUserCommand(pCmd, pBaseCmd, pInputEntry);
+	}
 }
 
 void F::MISC::MOVEMENT::BunnyHop(CUserCmd* pCmd, CBaseUserCmdPB* pUserCmd, C_CSPlayerPawn* pLocalPawn)

--- a/cstrike/features/misc/movement.cpp
+++ b/cstrike/features/misc/movement.cpp
@@ -29,6 +29,7 @@ void F::MISC::MOVEMENT::OnMove(CUserCmd* pCmd, CCSPlayerController* pLocalContro
 		return;
 
 	BunnyHop(pCmd, pBaseCmd, pLocalPawn);
+	AutoStrafe(pBaseCmd, pLocalPawn);
 
 	// loop through all tick commands
 	//for (int nTick = 0; nTick < pBaseCmd->nTickCount; nTick++)
@@ -74,6 +75,14 @@ void F::MISC::MOVEMENT::BunnyHop(CUserCmd* pCmd, CBaseUserCmdPB* pUserCmd, C_CSP
 	// im lazy so yea :D
 	if (pLocalPawn->GetFlags() & FL_ONGROUND)
 		pCmd->nButtons.nValue &= ~IN_JUMP;
+}
+
+void F::MISC::MOVEMENT::AutoStrafe(CBaseUserCmdPB* pUserCmd, C_CSPlayerPawn* pLocalPawn)
+{
+	if (!C_GET(bool, Vars.bAutoStrafe) || pLocalPawn->GetFlags() & FL_ONGROUND)
+		return;
+
+	pUserCmd->flSideMove = pUserCmd->nMousedX > 0 ? -1.0f : 1.0f; // a bit yanky, but works
 }
 
 void F::MISC::MOVEMENT::ValidateUserCommand(CUserCmd* pCmd, CBaseUserCmdPB* pUserCmd, CCSGOInputHistoryEntryPB* pInputEntry)

--- a/cstrike/features/misc/movement.h
+++ b/cstrike/features/misc/movement.h
@@ -14,6 +14,7 @@ namespace F::MISC::MOVEMENT
 	void OnMove(CUserCmd* pCmd, CCSPlayerController* pLocalController, C_CSPlayerPawn* pLocalPawn);
 
 	void BunnyHop(CUserCmd* pCmd, CBaseUserCmdPB* pUserCmd, C_CSPlayerPawn* pLocalPawn);
+	void AutoStrafe(CBaseUserCmdPB* pUserCmd, C_CSPlayerPawn* pLocalPawn);
 	void MovementCorrection(CBaseUserCmdPB* pUserCmd, CCSGOInputHistoryEntryPB* pInputHistory, const QAngle_t& angDesiredViewPoint);
 
 	// will call MovementCorrection && validate user's angView to avoid untrusted ban

--- a/cstrike/sdk/interfaces/imaterialsystem.h
+++ b/cstrike/sdk/interfaces/imaterialsystem.h
@@ -38,14 +38,14 @@ struct MaterialKeyVar_t
 	std::uint64_t FindKey(const char* szName)
 	{
 		using fnFindKeyVar = std::uint64_t(CS_FASTCALL*)(const char*, unsigned int, int);
-		static auto FindKeyVar = reinterpret_cast<fnFindKeyVar>(MEM::FindPattern(PARTICLES_DLL, CS_XOR("48 89 5C 24 ? 57 48 81 EC ? ? ? ? 33 C0 8B DA")));
+		static auto oFindKeyVar = reinterpret_cast<fnFindKeyVar>(MEM::FindPattern(PARTICLES_DLL, CS_XOR("48 89 5C 24 ? 57 48 81 EC ? ? ? ? 33 C0 8B DA")));
 
 #ifdef CS_PARANOID
-		CS_ASSERT(FindKeyVar != nullptr);
+		CS_ASSERT(oFindKeyVar != nullptr);
 #endif
 
 		// idk those enum flags, just saw it called like that soooo yea
-		return FindKeyVar(szName, 0x12, 0x31415926);
+		return oFindKeyVar(szName, 0x12, 0x31415926);
 	}
 };
 
@@ -57,7 +57,7 @@ class CObjectInfo
 
 class CSceneAnimatableObject
 {
-	MEM_PAD(0xA8);
+	MEM_PAD(0xB0);
 	CBaseHandle hOwner;
 };
 
@@ -69,36 +69,36 @@ public:
 	{
 		// @ida: #STR: shader, spritecard.vfx
 		using fnSetMaterialShaderType = void(CS_FASTCALL*)(void*, MaterialKeyVar_t, const char*, int);
-		static auto SetMaterialShaderType = reinterpret_cast<fnSetMaterialShaderType>(MEM::FindPattern(PARTICLES_DLL, CS_XOR("48 89 5C 24 ? 48 89 6C 24 ? 56 57 41 54 41 56 41 57 48 83 EC ? 0F B6 01 45 0F B6 F9 8B 2A 4D 8B E0 4C 8B 72 ? 48 8B F9 C0 E8 ? 24 ? 3C ? 74 ? 41 B0 ? B2 ? E8 ? ? ? ? 0F B6 07 33 DB C0 E8 ? 24 ? 3C ? 75 ? 48 8B 77 ? EB ? 48 8B F3 4C 8D 44 24 ? C7 44 24 ? ? ? ? ? 48 8D 54 24 ? 89 6C 24 ? 48 8B CE 4C 89 74 24 ? E8 ? ? ? ? 8B D0 83 F8 ? 75 ? 45 33 C9 89 6C 24 ? 4C 8D 44 24 ? 4C 89 74 24 ? 48 8B D7 48 8B CE E8 ? ? ? ? 8B D0 0F B6 0F C0 E9 ? 80 E1 ? 80 F9 ? 75 ? 48 8B 4F ? EB ? 48 8B CB 8B 41 ? 85 C0 74 ? 48 8D 59 ? 83 F8 ? 76 ? 48 8B 1B 48 63 C2 4D 85 E4")));
+		static auto oSetMaterialShaderType = reinterpret_cast<fnSetMaterialShaderType>(MEM::FindPattern(PARTICLES_DLL, CS_XOR("48 89 5C 24 ? 48 89 6C 24 ? 56 57 41 54 41 56 41 57 48 83 EC ? 0F B6 01 45 0F B6 F9 8B 2A 4D 8B E0 4C 8B 72 ? 48 8B F9 C0 E8 ? 24 ? 3C ? 74 ? 41 B0 ? B2 ? E8 ? ? ? ? 0F B6 07 33 DB C0 E8 ? 24 ? 3C ? 75 ? 48 8B 77 ? EB ? 48 8B F3 4C 8D 44 24 ? C7 44 24 ? ? ? ? ? 48 8D 54 24 ? 89 6C 24 ? 48 8B CE 4C 89 74 24 ? E8 ? ? ? ? 8B D0 83 F8 ? 75 ? 45 33 C9 89 6C 24 ? 4C 8D 44 24 ? 4C 89 74 24 ? 48 8B D7 48 8B CE E8 ? ? ? ? 8B D0 0F B6 0F C0 E9 ? 80 E1 ? 80 F9 ? 75 ? 48 8B 4F ? EB ? 48 8B CB 8B 41 ? 85 C0 74 ? 48 8D 59 ? 83 F8 ? 76 ? 48 8B 1B 48 63 C2 4D 85 E4")));
 
 #ifdef CS_PARANOID
-		CS_ASSERT(SetMaterialShaderType != nullptr);
+		CS_ASSERT(oSetMaterialShaderType != nullptr);
 #endif
 
 		MaterialKeyVar_t shaderVar(0x162C1777, CS_XOR("shader"));
-		SetMaterialShaderType(this, shaderVar, szShaderName, 0x18);
+		oSetMaterialShaderType(this, shaderVar, szShaderName, 0x18); // looks like this should be 0x19u in IDA?, not sure though. Leaving it likes for maecry
 	}
 
 	void SetMaterialFunction(const char* szFunctionName, int nValue)
 	{
 		using fnSetMaterialFunction = void(__fastcall*)(void*, MaterialKeyVar_t, int, int);
-		static auto SetMaterialFunction = reinterpret_cast<fnSetMaterialFunction>(MEM::FindPattern(PARTICLES_DLL, CS_XOR("48 89 5C 24 ? 48 89 6C 24 ? 56 57 41 54 41 56 41 57 48 83 EC ? 0F B6 01 45 0F B6 F9 8B 2A 48 8B F9")));
+		static auto oSetMaterialFunction = reinterpret_cast<fnSetMaterialFunction>(MEM::FindPattern(PARTICLES_DLL, CS_XOR("48 89 5C 24 ? 48 89 6C 24 ? 56 57 41 54 41 56 41 57 48 83 EC ? 0F B6 01 45 0F B6 F9 8B 2A 48 8B F9")));
 
 #ifdef CS_PARANOID
-		CS_ASSERT(SetMaterialFunction != nullptr);
+		CS_ASSERT(oSetMaterialFunction != nullptr);
 #endif
 
 		MaterialKeyVar_t functionVar(szFunctionName, true);
-		SetMaterialFunction(this, functionVar, nValue, 0x18);
+		oSetMaterialFunction(this, functionVar, nValue, 0x18);
 	}
 
-	MEM_PAD(0x10); // 0x0
-	CSceneAnimatableObject* pSceneAnimatableObject; // 0x10
-	CMaterial2* pMaterial; // 0x18
-	MEM_PAD(0x20); // 0x20
-	Color_t colValue; // 0x40
-	MEM_PAD(0x4); // 0x44
-	CObjectInfo* pObjectInfo; // 0x48
+	MEM_PAD(0x18); // 0x0
+	CSceneAnimatableObject* pSceneAnimatableObject; // 0x18
+	CMaterial2* pMaterial; // 0x20
+	MEM_PAD(0x20); // 0x28
+	Color_t colValue; // 0x48
+	MEM_PAD(0x4); // 0x4C
+	CObjectInfo* pObjectInfo; // 0x50
 };
 
 class IMaterialSystem2


### PR DESCRIPTION
A simple crash fix for chams,  setting color doesn't work nor does wireframe material ( on debug )
Fixed the createmove arguments, after taking a look in IDA the last byte arg is no longer there
Added back input history
Added a simple autostrafer too