### PR TITLE
Correct previously incorrect globalvars, TICK_INTERVAL set value

### DIFF
--- a/cstrike/core/interfaces.h
+++ b/cstrike/core/interfaces.h
@@ -19,7 +19,7 @@
 #define RESOURCE_HANDLE_UTILS CS_XOR("ResourceHandleUtils001")
 
 // @source: master/game/shared/shareddefs.h
-#define TICK_INTERVAL (I::GlobalVars->flIntervalPerTick)
+#define TICK_INTERVAL 0.015625f
 #define TIME_TO_TICKS(TIME) (static_cast<int>(0.5f + static_cast<float>(TIME) / TICK_INTERVAL))
 #define TICKS_TO_TIME(TICKS) (TICK_INTERVAL * static_cast<float>(TICKS))
 #define ROUND_TO_TICKS(TIME) (TICK_INTERVAL * TIME_TO_TICKS(TIME))

--- a/cstrike/sdk/interfaces/iglobalvars.h
+++ b/cstrike/sdk/interfaces/iglobalvars.h
@@ -3,7 +3,6 @@
 // used: mem_pad
 #include "../../utilities/memory.h"
 
-// Some of this might be incorrect, using this struct fixed everything in my cheat
 class IGlobalVars
 {
 public:
@@ -11,15 +10,14 @@ public:
 	int32_t nFrameCount; //0x0004
 	float flFrameTime; //0x0008
 	float flFrameTime2; //0x000C
-	int32_t nMaxClients; //0x0010
-	MEM_PAD(0xC);
-	// Everything under this commend is suppose to be in it's own class inside globalvariables,
-	// but I'm too lazy to do that, so I'm just going to leave it here.
-	MEM_PAD(0x8);
-	float flIntervalPerTick; // 0x0008
-	float flCurrentTime; //0x000C
-	float flCurrentTime2; //0x0010
-	MEM_PAD(0x148);
-	char* szCurrentMap; //0x0164
-	char* szCurrentMapName; //0x016C
+	int32_t m_nMaxClients; //0x0010
+	MEM_PAD(0x14);
+	float flFrameTime3; //0x0028
+	float flCurrentTime; //0x002C
+	float flCurrentTime2; //0x0030
+	MEM_PAD(0xC); //0x0034
+	int32_t nTickCount; //0x0040
+	MEM_PAD(0x138); //0x0044
+	char* szCurrentMap; //0x017C
+	char* szCurrentMapName; //0x0180
 };

--- a/cstrike/sdk/interfaces/iglobalvars.h
+++ b/cstrike/sdk/interfaces/iglobalvars.h
@@ -10,7 +10,7 @@ public:
 	int32_t nFrameCount; //0x0004
 	float flFrameTime; //0x0008
 	float flFrameTime2; //0x000C
-	int32_t m_nMaxClients; //0x0010
+	int32_t nMaxClients; //0x0010
 	MEM_PAD(0x14);
 	float flFrameTime3; //0x0028
 	float flCurrentTime; //0x002C


### PR DESCRIPTION
Realized a previous pull request I made for globalvariables were incorrect. Had completely forgotten about it.
Seeing how global variables no longer have a tick interval var and how valve is currently using a constant variable. 
I decided to change TICK_INTERVAL to the same value as Valve uses