### PR TITLE
fix: corrected SDL_Window offset at IInputSystem::GetSDLWindow()

### DIFF
--- a/cstrike/sdk/interfaces/iinputsystem.h
+++ b/cstrike/sdk/interfaces/iinputsystem.h
@@ -15,6 +15,6 @@ public:
 	void* GetSDLWindow()
 	{
 		// @ida: IInputSystem::DebugSpew -> #STR: "Current coordinate bias %s: %g,%g scale %g,%g\n"
-		return *reinterpret_cast<void**>(reinterpret_cast<std::uintptr_t>(this) + 0x2678);
+		return *reinterpret_cast<void**>(reinterpret_cast<std::uintptr_t>(this) + 0x26A8);
 	}
 };


### PR DESCRIPTION
Changed the offset @ IInputSystem::GetSDLWindow() function.
The offset is found via searching in memory in debugger and calculated by substracting from the interface pointer.