### PR TITLE
Update More Patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Live Update
+enc_temp_folder

--- a/cstrike/core/hooks.cpp
+++ b/cstrike/core/hooks.cpp
@@ -234,9 +234,16 @@ bool CS_FASTCALL H::CreateMove(CCSGOInput* pInput, int nSlot, CUserCmd* cmd)
 
 	F::OnCreateMove(SDK::Cmd, pBaseCmd, SDK::LocalController);
 
+	// TODO : We need to fix CRC saving
+	// 
+	// There seems to be an issue within CBasePB and the classes that derive it.
+	// So far, you may be unable to press specific keys such as crouch and automatic shooting.
+	// A dodgy fix would be to comment it out but it still doesn't fix the bhop etc.
+
 	CRC::Save(pBaseCmd);
 	if (CRC::CalculateCRC(pBaseCmd) == true)
 		CRC::Apply(SDK::Cmd);
+
 
 	return bResult;
 }

--- a/cstrike/core/hooks.cpp
+++ b/cstrike/core/hooks.cpp
@@ -85,7 +85,11 @@ bool H::Setup()
 	L_PRINT(LOG_INFO) << CS_XOR("\"GetMatrixForView\" hook has been created");
 
 	// @ida: #STR: cl: CreateMove clamped invalid attack history index %d in frame history to -1. Was %d, frame history size %d.\n
-	if (!hkCreateMove.Create(MEM::GetVFunc(I::Input, VTABLE::CLIENT::CREATEMOVE), reinterpret_cast<void*>(&CreateMove)))
+	// Consider updating I::Input, VTABLE::CLIENT::CREATEMOVE and using that instead.
+
+	// For now, we'll use the pattern
+	// Credit: https://www.unknowncheats.me/forum/4265695-post6331.html
+	if (!hkCreateMove.Create(MEM::FindPattern(CLIENT_DLL, CS_XOR("48 8B C4 4C 89 40 ? 48 89 48 ? 55 53 56 57 48 8D A8")), reinterpret_cast<void*>(&CreateMove)))
 		return false;
 	L_PRINT(LOG_INFO) << CS_XOR("\"CreateMove\" hook has been created");
 

--- a/cstrike/core/hooks.cpp
+++ b/cstrike/core/hooks.cpp
@@ -124,7 +124,8 @@ bool H::Setup()
 
 	//L_PRINT(LOG_INFO) << CS_XOR("\"OverrideView\" hook has been created");
 
-	if (!hkDrawObject.Create(MEM::FindPattern(SCENESYSTEM_DLL, CS_XOR("48 8B C4 53 41 56 48 83 EC 38 4D 8B F0 48 8B DA 48 85 C9 0F 84 99 01 ? ?")), reinterpret_cast<void*>(&DrawObject)))
+	// Credit: https://www.unknowncheats.me/forum/4253223-post6185.html
+	if (!hkDrawObject.Create(MEM::FindPattern(SCENESYSTEM_DLL, CS_XOR("48 8B C4 48 89 50 ? 53")), reinterpret_cast<void*>(&DrawObject)))
 		return false;
 	L_PRINT(LOG_INFO) << CS_XOR("\"DrawObject\" hook has been created");
 

--- a/cstrike/core/hooks.h
+++ b/cstrike/core/hooks.h
@@ -34,7 +34,7 @@ namespace VTABLE
 	{
 		enum
 		{
-			CREATEMOVE = 21U,
+			CREATEMOVE = 21U, // Outdated (Using pattern for now)
 			MOUSEINPUTENABLED = 19U,
 			FRAMESTAGENOTIFY = 36U,
 		};

--- a/cstrike/cstrike.vcxproj
+++ b/cstrike/cstrike.vcxproj
@@ -42,7 +42,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LinkIncremental>false</LinkIncremental>
+    <LinkIncremental>true</LinkIncremental>
     <IgnoreImportLibrary>true</IgnoreImportLibrary>
     <OutDir>$(SolutionDir)build\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)intermediate\$(ProjectName)\$(Configuration)\</IntDir>
@@ -65,7 +65,7 @@
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>NOMINMAX;_DEBUG;_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)dependencies;$(SolutionDir)dependencies\freetype\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
       <SupportJustMyCode>false</SupportJustMyCode>
       <MinimalRebuild>false</MinimalRebuild>

--- a/cstrike/features/visuals/chams.cpp
+++ b/cstrike/features/visuals/chams.cpp
@@ -119,7 +119,7 @@ bool F::VISUALS::CHAMS::OverrideMaterial(void* pAnimatableSceneObjectDesc, void*
 	const auto oDrawObject = H::hkDrawObject.GetOriginal();
 	const CustomMaterial_t customMaterial = arrMaterials[C_GET(int, Vars.nVisualChamMaterial)];
 
-	if (C_GET(bool, Vars.bVisualChamsIgnoreZ))
+	if (C_GET(bool, Vars.bVisualChamsIgnoreZ)) // Ignore Invisible
 	{
 		arrMeshDraw->pMaterial = customMaterial.pMaterialInvisible;
 		arrMeshDraw->colValue = C_GET(Color_t, Vars.colVisualChamsIgnoreZ);

--- a/cstrike/sdk/entity.h
+++ b/cstrike/sdk/entity.h
@@ -220,7 +220,8 @@ public:
 	[[nodiscard]] Vector_t GetEyePosition()
 	{
 		Vector_t vecEyePosition = Vector_t(0.0f, 0.0f, 0.0f);
-		MEM::CallVFunc<void, 166U>(this, &vecEyePosition);
+		// Credit: https://www.unknowncheats.me/forum/4258133-post6228.html
+		MEM::CallVFunc<void, 169U>(this, &vecEyePosition);
 		return vecEyePosition;
 	}
 };

--- a/cstrike/sdk/interfaces/cgametracemanager.h
+++ b/cstrike/sdk/interfaces/cgametracemanager.h
@@ -94,7 +94,8 @@ public:
 	bool TraceShape(Ray_t* pRay, Vector_t vecStart, Vector_t vecEnd, TraceFilter_t* pFilter, GameTrace_t* pGameTrace)
 	{
 		using fnTraceShape = bool(__fastcall*)(CGameTraceManager*, Ray_t*, Vector_t*, Vector_t*, TraceFilter_t*, GameTrace_t*);
-		static fnTraceShape oTraceShape = reinterpret_cast<fnTraceShape>(MEM::GetAbsoluteAddress(MEM::FindPattern(CLIENT_DLL, CS_XOR("E8 ? ? ? ? 80 7D ? ? 75 ? F3 0F 10 45")), 0x1, 0x0));
+		// Credit: https://www.unknowncheats.me/forum/4265752-post6333.html
+		static fnTraceShape oTraceShape = reinterpret_cast<fnTraceShape>(MEM::FindPattern(CLIENT_DLL, CS_XOR("48 89 5C 24 20 48 89 4C 24 08 55 56 41")));
 
 		#ifdef CS_PARANOID
 		CS_ASSERT(oTraceShape != nullptr);

--- a/cstrike/sdk/interfaces/imaterialsystem.h
+++ b/cstrike/sdk/interfaces/imaterialsystem.h
@@ -94,13 +94,16 @@ public:
 		oSetMaterialFunction(this, functionVar, nValue, 0x18);
 	}
 
+	// Credit: https://www.unknowncheats.me/forum/4270816-post6392.html
+
 	MEM_PAD(0x18); // 0x0
 	CSceneAnimatableObject* pSceneAnimatableObject; // 0x18
 	CMaterial2* pMaterial; // 0x20
-	MEM_PAD(0x18); // 0x28
-	Color_t colValue; // 0x40
-	MEM_PAD(0x4); // 0x44
-	CObjectInfo* pObjectInfo; // 0x48
+	CMaterial2* pMaterialCpy; // 0x28
+	MEM_PAD(0x10);
+	CObjectInfo* pObjectInfo;
+	MEM_PAD(0x8);
+	Color_t colValue;
 };
 
 class IMaterialSystem2


### PR DESCRIPTION
There are some problems that still remain, namely the CBasePB seems to be outdated, so key presses are not saved between `CreateMove`s, hopefully someone else can help me out with that.

Here's what I changed:

- Tweak some debug tools so that you can easily live update the debug build
- Fix the `GetEyePosition` function to match new VTABLE index
- Fix TraceShape, DrawObject Patterns
- Update CreateMove to use pattern (As I don't know the VTABLE index, I commented this to let others know it is out of date)
- Add some comments on some changes providing sources to where I got the patterns from
- Update "CMeshData" structure -- which fixed the chams' colour

If you do wish to merge this, maybe squash this merge sicne my commits were quite frequent as to document each fix.

Hope this helps!